### PR TITLE
fix: 修复 subPackages 的 root 为多级目录时错误

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -13,7 +13,7 @@ import { debug } from './utils/debug';
 import { checkFileSync, detectIndent } from './utils/file';
 import { deepAssign } from './utils/object';
 import { currentPlatform, type UniPlatform } from './utils/uni-env';
-import { sleep } from './utils/utils';
+import { slash, sleep } from './utils/utils';
 
 interface JsonFileInfo {
   indent: string | number;
@@ -90,8 +90,7 @@ export class Context {
 
     // subPackages, 先处理 subPackages 避免重复出现在 pages 里
     for (const dir of this.cfg.subPackageDirs) {
-
-      const root = path.basename(dir);
+      const root = slash(path.relative(this.cfg.src, dir));
 
       for (const file of listFiles(dir, { cwd: this.cfg.root, ignore: this.cfg.exclude })) {
         if (files.has(file)) {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -3,3 +3,7 @@ export function noop() {}
 export function sleep(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+export function slash(str: string) {
+  return str.replace(/\\/g, '/');
+}


### PR DESCRIPTION
subPackages 的 `root` 应该是相对于 `src` 的路径，以兼容多级目录作为 `root` 的情况。

例如，输入 `"packages/core"` 预期的 `root` 应该是 `packages/core`，但现在是 `core`。