### PR TITLE
feat: 添加 transformPage 钩子以支持页面配置的自定义修改

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,24 @@ export interface UserConfig {
    */
   indent?: string | number;
 }
+
+export interface ConfigHook {
+  /**
+   * 获取页面路径
+   */
+  parsePageOption?: (opt: PageFileOption) => MaybePromise<PageFileOption>;
+
+  /**
+   * 过滤、修改 pages 的页面文件信息
+   */
+  filterPages?: (platform: UniPlatform, opts: PageFileOption[]) => MaybePromise<PageFileOption[]>;
+
+  /**
+   * 修改生成的页面配置
+   * 返回 null 可忽略该页面
+   */
+  transformPage?: (platform: UniPlatform, page: Page, opt: PageFileOption) => MaybePromise<Page | null>;
+}
 ```
 
 ## 📄 动态配置文件

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import type * as PagesJSON from '@uni-ku/pages-json/types';
 import type { PageFileOption } from './page-file';
 import type { MaybePromise } from './types';
 import type { UniPlatform } from './utils/uni-env';
@@ -19,6 +20,11 @@ export interface ConfigHook {
    * 过滤、修改 pages 的页面文件信息
    */
   filterPages?: (platform: UniPlatform, opts: PageFileOption[]) => MaybePromise<PageFileOption[]>;
+  /**
+   * 修改生成的页面配置
+   * 返回 null 可忽略该页面
+   */
+  transformPage?: (platform: UniPlatform, page: PagesJSON.Page, opt: PageFileOption) => MaybePromise<PagesJSON.Page | null>;
 }
 
 export interface UserConfig {

--- a/src/context.ts
+++ b/src/context.ts
@@ -285,7 +285,8 @@ export class Context {
    */
   private async generatePages(platform = currentPlatform()): Promise<PagesJSON.Page[]> {
     const pageFiles = await this.getMainPageFiles(platform);
-    return Promise.all(pageFiles.map(async pf => pf.getPage(platform))).then(pages => pages.filter(p => !!p));
+    return Promise.all(pageFiles.map(async pf => this.transformPage(platform, pf, await pf.getPage(platform))))
+      .then(pages => pages.filter(p => !!p));
   }
 
   /**
@@ -301,7 +302,8 @@ export class Context {
       }
       subPackages[pf.root] = subPackages[pf.root] || { root: pf.root, pages: [] };
 
-      const page = await pf.getPage(platform);
+      const page = await this.transformPage(platform, pf, await pf.getPage(platform));
+
       if (page) {
         subPackages[pf.root].pages.push(page);
       }
@@ -323,6 +325,33 @@ export class Context {
       }
     }
     return items;
+  }
+
+  private getPageFileOption(pf: PageFile): PageFileOption {
+    return {
+      filePath: pf.file,
+      pagePath: pf.path,
+      root: pf.root || undefined,
+    };
+  }
+
+  private async transformPage(platform: UniPlatform, pf: PageFile, page: PagesJSON.Page | null): Promise<PagesJSON.Page | null> {
+    if (!page) {
+      return null;
+    }
+
+    const opt = this.getPageFileOption(pf);
+
+    for (const hook of this.cfg.hooks) {
+      if (hook.transformPage) {
+        page = await hook.transformPage(platform, page, opt);
+        if (!page) {
+          return null;
+        }
+      }
+    }
+
+    return page;
   }
 
   private async needUpdate(filepath?: string): Promise<boolean> {

--- a/test/generate.spec.ts
+++ b/test/generate.spec.ts
@@ -124,4 +124,50 @@ describe('generate', async () => {
       }"
       `);
   });
+
+  it('transformPage hook', async () => {
+    const hookedCtx = new Context(resolveConfig({
+      root: path.resolve(__dirname, '../playground'),
+      pageDir: 'pages',
+      subPackageDirs: ['pages-sub'],
+      platform: ['h5'],
+      hooks: [
+        {
+          transformPage(platform, page, opt) {
+            return {
+              ...page,
+              style: {
+                ...page.style,
+                navigationBarBackgroundColor: opt.root ? '#111111' : '#222222',
+                navigationBarTextStyle: platform === 'h5' ? 'white' : 'black',
+              },
+            };
+          },
+        },
+      ],
+    }));
+
+    await hookedCtx.scanFiles();
+
+    const pagesJson = await hookedCtx.generatePagesJson('h5');
+    const mainPage = pagesJson.pages?.find(page => page.path === 'pages/index/index');
+    const subPage = pagesJson.subPackages
+      ?.find(subPackage => subPackage.root === 'pages-sub')
+      ?.pages
+      .find(page => page.path === 'index');
+
+    expect(mainPage).toMatchObject({
+      style: {
+        navigationBarBackgroundColor: '#222222',
+        navigationBarTextStyle: 'white',
+      },
+    });
+
+    expect(subPage).toMatchObject({
+      style: {
+        navigationBarBackgroundColor: '#111111',
+        navigationBarTextStyle: 'white',
+      },
+    });
+  });
 });


### PR DESCRIPTION
## 背景

在实际使用中，发现支付宝小程序不支持页面配置里的：

```ts
{
  navigationStyle: 'custom',
}
```

但同样的需求可以通过支付宝小程序支持的配置来实现，例如：

```ts
{
  transparentTitle: 'always',
  titlePenetrate: 'YES',
}
```

目前插件虽然支持通过 `definePage` 在单页内声明配置，也支持对页面文件列表做过滤和预处理，但缺少一个“在最终生成每个页面配置时统一改写”的扩展点。  
这导致像“按平台把某类页面配置转换成另一套兼容配置”这样的需求，不太方便处理。