### PR TITLE
fix(hooks): filterPages 正则跨目录匹配导致含点路径页面被误过滤

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -7,7 +7,11 @@ export const hookUniPlatform: ConfigHook = {
   },
   filterPages: (platform, opts) => {
     return opts.filter((opt) => {
-      const matched = opt.filePath.match(/([^.]+)\.([^.]+)\.([^.]+)$/);
+      // 仅在文件名（basename）上匹配 name.platform.ext，
+      // 避免 [^.]+ 跨目录分隔符匹配到路径中的点（如 /root/.jenkins/...），
+      // 导致 matched[2] 错误地命中路径段而非平台后缀
+      const basename = opt.filePath.replace(/^.*[\\/]/, '');
+      const matched = basename.match(/([^.]+)\.([^.]+)\.([^.]+)$/);
       return !matched || matched[2] === platform;
     });
   },

--- a/test/hooks.spec.ts
+++ b/test/hooks.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { hookUniPlatform } from '../src/hooks';
+
+function filter(platform: 'h5' | 'mp-weixin', filePaths: string[]) {
+  return hookUniPlatform.filterPages!(platform, filePaths.map(filePath => ({ filePath, pagePath: filePath })));
+}
+
+describe('hookUniPlatform.filterPages', () => {
+  it('保留无平台后缀的默认页面', async () => {
+    const result = await filter('h5', ['src/pages/index/index.vue']);
+    expect(result).toHaveLength(1);
+  });
+
+  it('保留匹配平台页面，过滤其他平台', async () => {
+    const result = await filter('h5', [
+      'src/pages/index/index.h5.vue',
+      'src/pages/index/index.mp-weixin.vue',
+    ]);
+    expect(result.map(o => o.filePath)).toEqual(['src/pages/index/index.h5.vue']);
+  });
+
+  // 回归：旧正则 [^.]+ 跨 / 匹配，路径中的点（如 /root/.jenkins/）使 matched[2]
+  // 错误命中路径段而非平台后缀，导致默认页面被全部过滤（pages.json pages 为空）
+  it('绝对路径含点（.jenkins）不误过滤默认页面', async () => {
+    const result = await filter('h5', ['/root/.jenkins/workspace/proj/src/pages/index/index.vue']);
+    expect(result).toHaveLength(1);
+  });
+
+  it('绝对路径含点时仍按平台后缀过滤', async () => {
+    const result = await filter('h5', [
+      '/root/.jenkins/workspace/proj/src/pages/index/index.h5.vue',
+      '/root/.jenkins/workspace/proj/src/pages/index/index.mp-weixin.vue',
+    ]);
+    expect(result.map(o => o.filePath)).toEqual(['/root/.jenkins/workspace/proj/src/pages/index/index.h5.vue']);
+  });
+
+  it('windows 绝对路径正常', async () => {
+    const result = await filter('h5', ['E:\\platform\\proj\\src\\pages\\index\\index.vue']);
+    expect(result).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
hookUniPlatform.filterPages 的正则 [^.]+ 包含 /，会跨目录分隔符匹配。 filePath 为绝对路径且路径含点（如 Jenkins /root/.jenkins/...）时， .jenkins 的点使 matched[2] 错误命中路径段而非平台后缀，导致所有页面
被过滤，pages.json pages 为空，构建报 pages must contain at least 1 page。

改为先取 basename 再匹配，正则本身不变，仅缩小匹配范围到文件名。
新增 test/hooks.spec.ts 回归测试。